### PR TITLE
Fix panic on entries range selection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,8 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
 
     let cleaned_input = &input[state.config.prefix.len()..];
     if cleaned_input.is_empty() {
-        let entries = &state.history[..state.config.max_entries];
+        let max_entries = state.history.len().min(state.config.max_entries);
+        let entries = &state.history[..max_entries];
         entries
             .into_iter()
             .map(|(id, _, entry)| {


### PR DESCRIPTION
A panic occured when the plugin was called with less items in cliphist's memory than the `max_entries` config variable; for example, after `cliphist wipe`:
```
thread '<unnamed>' panicked at 'range end index 10 out of range for slice of length 0', src/lib.rs:114:24
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', src/lib.rs:54:1
```

This PR fixes the issue by taking a minimum between `max_entries` and the history length.